### PR TITLE
Remove mandel references in FC submodule

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-eosnetworkfoundation/fc
+AntelopeIO/fc
 
 Copyright (c) 2021-2022 EOS Network Foundation (ENF) and its contributors.  All rights reserved. 
 This ENF software is based upon:


### PR DESCRIPTION
Replace `mandel-fc` with `fc` in `LICENSE.txt`.