### PR TITLE
sha3.hpp: fix compile error with Boost 1.79

### DIFF
--- a/include/fc/crypto/sha3.hpp
+++ b/include/fc/crypto/sha3.hpp
@@ -3,6 +3,7 @@
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
 #include <fc/io/raw_fwd.hpp>
+#include <boost/functional/hash.hpp>
 
 namespace fc
 {


### PR DESCRIPTION
Resolve https://github.com/AntelopeIO/leap/issues/31

When compile `benchmark/hash.cpp `on Ubuntu 18.04 where Boost is 1.79, following  error was reported:

```
In file included from ../benchmark/hash.cpp:2:
../libraries/fc/include/fc/crypto/sha3.hpp:105:8: error: 'hash' is not a class template
 struct hash<fc::sha3>
        ^~~~
../libraries/fc/include/fc/crypto/sha3.hpp:106:1: error: explicit specialization of non-template 'boost::hash'
```

Compiles on Ubuntu 20.04 and 22.04 were fine.

Fix is to include `<boost/functional/hash.hpp>` in `sha3.hpp`.